### PR TITLE
fix changelog syntax error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,9 @@
 {
   "root": true,
-  "extends": "nugit/script"
+  "extends": "nugit/script",
+  "parser": "espree",
+  "parserOptions": {
+    "ecmaVersion": 2019,
+    "sourceType": "module"
+  }
 }

--- a/src/changelog/body.js
+++ b/src/changelog/body.js
@@ -46,7 +46,7 @@ async function addChangelog(octokit, owner, repo, pr, changelog) {
 }
 
 function getBodyChangelog(pr) {
-  const [, changes = null] = pr.body?.split(MARKER) ?? [];
+  const [, changes = null] = pr.body ? pr.body.split(MARKER) : [];
 
   const lines = [
     `## ${pr.title} #${pr.number}`,


### PR DESCRIPTION
According to `action.yml` we're using `nodejs12` which only supports `ES2019`