### PR TITLE
Fix Show User Input Instead Of JIRA Bot Input

### DIFF
--- a/src/changelog/jira.js
+++ b/src/changelog/jira.js
@@ -1,21 +1,23 @@
 function findJiraTicket(prs) {
   const lines = prs.flatMap(pr => (pr.body ? pr.body.split('\n') : []));
 
-  const linesMap = new Map(
-    lines
-      .filter(line => line.includes('atlassian.net'))
-      .reduce((acc, line) => {
-        const match = line.match(
-          /https:\/\/nugitco.atlassian.net\/browse\/(\w+-\w+)/,
-        );
+  const linesMap = lines
+    .filter(line => line.includes('atlassian.net'))
+    .reduce((acc, line) => {
+      const match = line.match(
+        /https:\/\/nugitco.atlassian.net\/browse\/(\w+-\w+)/,
+      );
 
-        if (match) {
-          acc.push([match[1], line]);
+      if (match) {
+        const jiraTicketNo = match[1];
+
+        if (!acc.has(jiraTicketNo)) {
+          acc.set(jiraTicketNo, line);
         }
+      }
 
-        return acc;
-      }, []),
-  );
+      return acc;
+    }, new Map());
 
   return Array.from(linesMap.values());
 }


### PR DESCRIPTION
**Changes:**
- Issue: JIRA bot will add a reference link to the ticket at the bottom of the PR changelog 
- Fix: Return the first value (i.e. user input) found for the JIRA ticket number instead of the last value (i.e. JIRA bot)